### PR TITLE
Export shader_precache module in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ pub mod tab;
 pub(crate) mod utils;
 /// Extended Compositor Messages for PipelineId association
 pub mod extended_compositor_msg;
+/// Shader precaching configuration
+pub mod shader_precache;
 
 /// WebGL support infrastructure.
 /// This module is only available when the `webgl` feature is enabled.


### PR DESCRIPTION
Makes the shader_precache module public so it can be used in verso.rs for configuring WebRender shader precaching behavior.