### PR TITLE
feat(compositor): migrate resource tracking to PainterId-based HashMap (#31)

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1306,7 +1306,7 @@ impl IOCompositor {
     }
 
     fn remove_pipeline_root_layer(&mut self, pipeline_id: PipelineId) {
-        self.pipeline_details.remove(&pipeline_id);
+        self.remove_pipeline_details_recursively(pipeline_id);
     }
 
     /// Change the current window of the compositor should display.


### PR DESCRIPTION
## Summary

Completes Phases 3 & 4 of issue #31: migrates compositor resource tracking from per-pipeline (`PipelineId`) to per-painter (`PainterId`) using Servo's new `PaintMessage` API.

Closes #31

## Changes

### Phase 3: Resource Tracking Migration (commit `e4a029c`)

**Infrastructure:**
- Added `painter_resources: HashMap<PainterId, PainterResources>` to `IOCompositor`
- Added `painter_resources()` helper method with entry-or-insert pattern
- Updated `PainterResources` doc comments from "pipeline" to "painter"

**Method signatures updated:**
- `add_font()`: `Option<PipelineId>` -> `PainterId`
- `add_font_instance()`: `Option<PipelineId>` -> `PainterId`
- `add_image()`: `Option<PipelineId>` -> `PainterId`

**Handler updates:**
- `AddSystemFont`: Now tracks font via `painter_resources`
- `UpdateImages`: Now tracks `AddImage` keys via `painter_resources`
- `RemoveFonts`: Added cleanup to remove keys from tracked resources

**Cleanup:**
- Removed `resources: PainterResources` from `PipelineDetails` struct
- Simplified `remove_pipeline_details_recursively()` and `remove_pipeline_root_layer()`

### Phase 4: Testing & Cleanup (commit `771207f`)

- Fixed missing semicolon in `UpdateImages` `AddImage` handler
- Renamed `test_pipeline_resources_clear` -> `test_painter_resources_clear`
- Added `test_painter_resources_add_tracks_keys` test
- Added `test_painter_resources_retain_after_remove` test
- Deleted 5 obsolete branches (Option A / old E2 approach)

## Related Issues

- Supersedes #10 (E2.3) - closed as "not planned" since this PR implements resource tracking via `PainterId` instead of per-`PipelineId`
- Independent of #12, #13 (scroll coalescing) and #14, #15, #16 (shader precaching)

## Testing

- 3 unit tests for `PainterResources`: clear, add tracking, retain-after-remove
- All tests use `mockall` for `TransactionTrait` mocking