### PR TITLE
feat(scroll-coalescing): implement A3.2 scroll event coalescing (#12)

### DIFF
--- a/src/scroll_coalescing.rs
+++ b/src/scroll_coalescing.rs
@@ -121,7 +121,7 @@ impl ScrollCoalescer {
 
                             // Average the deltas (same logic as process_pending_scroll_events)
                             existing.scroll_location = ScrollLocation::Delta(
-                                (existing_delta * old_scale.0 + delta) / new_scale.0
+                                (existing_delta * old_scale.0 + delta * event.event_count as f32) / new_scale.0
                             );
                             existing.event_count = new_count;
                         }


### PR DESCRIPTION
## Summary

Implements A3.2: Scroll event coalescing logic as specified in Issue #12.

## Changes

- Refactored `ScrollCoalescer` to use `HashMap<DeviceIntPoint, ScrollEvent>` for cursor-based batching
- `add_event()` now accepts `ScrollEvent` with `ScrollLocation` awareness (Delta/Start/End)
- Delta events at the same cursor position are combined using weighted averaging
- Start/End events trigger immediate flush and are not coalesced  
- Threshold-based flushing when max cursor positions reached
- Added comprehensive unit tests covering all acceptance criteria

## Acceptance Criteria

- [x] Delta events at same cursor position are combined
- [x] Start/End events trigger immediate flush
- [x] Event counts are properly tracked for averaging
- [x] Threshold-based flushing works correctly
- [x] Unit tests pass for coalescing logic

## Note

This PR has merge conflicts with main due to the concurrent PR #35 changes. These will need to be resolved before merging.

Closes #12