### PR TITLE
Remove zune-image git patches to fix zune-core type/trait mismatch on Windows CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,10 +198,3 @@ lto = true
 [lints.rust]
 unexpected_cfgs = "allow"
 
-# Patch for zune-jpeg and zune-core to fix Rust 2024 edition / aarch64 unsafe function errors.
-# Both crates must be pinned to the same git rev to avoid type/trait mismatches.
-# When bumping, update both zune-jpeg and zune-core revs together.
-[patch.crates-io]
-zune-jpeg = { git = "https://github.com/etemesi254/zune-image.git", rev = "7cb6c7d" }
-zune-core = { git = "https://github.com/etemesi254/zune-image.git", rev = "7cb6c7d" }
-

--- a/docs/issues/windows-build-zune-core-mismatch.md
+++ b/docs/issues/windows-build-zune-core-mismatch.md
@@ -1,0 +1,21 @@
+# Issue: Windows build fails with zune-core/zune-jpeg type mismatch
+
+## Summary
+Windows CI fails building the `image` crate with trait/type mismatches between
+`zune_core` and `zune_jpeg`, indicating two different `zune-core` sources are
+compiled simultaneously.
+
+## Error signature
+The failures show mismatched `ZByteReaderTrait` bounds and `DecoderOptions`
+types coming from two different `zune_core` crates.
+
+## Hypothesis
+We were overriding `zune-jpeg` and `zune-core` to a git source while `image`
+still pulled `zune-core` from crates.io, leaving two sources in the graph.
+
+## Proposed fix
+Remove the git patches so `image`, `zune-jpeg`, and `zune-core` resolve to the
+same crates.io sources.
+
+## Branch
+`issue/windows-zune-core-mismatch`


### PR DESCRIPTION
### Motivation
- Windows CI failed building the `image` crate with trait/type mismatches originating from duplicate `zune_core` sources in the dependency graph. 
- The project had git `patch.crates-io` overrides for `zune-jpeg`/`zune-core` which likely caused the crate to be pulled from two different sources and produced incompatible types. 

### Description
- Removed the `zune-jpeg` and `zune-core` git patch overrides from `Cargo.toml` so all crates resolve to the same crates.io versions. 
- Added `docs/issues/windows-build-zune-core-mismatch.md` documenting the failure, hypothesis, proposed fix, and tracking branch. 
- Created branch `issue/windows-zune-core-mismatch` and committed the changes for follow-up validation in CI. 

### Testing
- Attempted to inspect dependency resolution with `cargo tree -i zune-core`, but the command failed due to network access errors to the crates.io index (HTTP 403), so dependency resolution could not be validated automatically. 
- No CI build or crate compilation was completed in this change due to the blocked network; further verification should run in CI where crates.io is accessible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875acee8048324a027af7604a0aaff)