### PR TITLE
docs: Add issue tracking files for 302 compilation errors from PR fas…

### DIFF
--- a/docs/issues/issue-43-webrender-api-dual-version-conflict.md
+++ b/docs/issues/issue-43-webrender-api-dual-version-conflict.md
@@ -1,0 +1,60 @@
+# Issue #43: Fix webrender_api dual version conflict causing ~60 type mismatch errors
+
+## Summary
+
+Two different versions of `webrender_api` are being pulled into the dependency tree, causing widespread type mismatch errors across `compositor.rs` and `webview/` files. This is the **root cause** of approximately 60 of the 302 total compilation errors.
+
+## Root Cause
+
+- **Direct dependency**: `webrender_api` from `git = "https://github.com/servo/webrender", branch = "0.68"` (the git checkout version)
+- **Transitive dependency**: `webrender_api 0.68.0` from `crates.io` pulled in via `base` → `servo_malloc_size_of` → `webrender_api`
+
+The compiler reports:
+```
+note: two different versions of crate `webrender_api` are being used
+  /home/runner/.cargo/registry/src/.../webrender_api-0.68.0/src/...  (crates.io version)
+  /home/runner/.cargo/git/checkouts/webrender-.../webrender_api/src/...  (git version)
+```
+
+## Affected Types
+
+All of the following types exist in both versions, causing "expected X, found a different X" errors:
+
+- `ExternalScrollId` — scroll offset tracking in compositor
+- `PipelineId` / `WebRenderPipelineId` — pipeline identification
+- `FontKey` / `FontInstanceKey` / `NativeFontHandle` / `FontInstanceFlags` — font resource management
+- `ImageKey` — image resource management
+- `DevicePixel` / `LayoutPixel` — coordinate system units
+- `Epoch` / `BuiltDisplayListDescriptor` — display list metadata
+- `ScrollLocation` — scroll event types
+
+## Affected Files
+
+- `src/compositor.rs` — lines 396, 401, 763, 786, 822, 834, 838, 841, 848, 854, 855, 861, 864, 884, 887, 949, 952, 1170, 1254, 1509, 1808+
+- `src/webview/webview.rs` — lines 51, 549, 563
+- `src/webview/prompt.rs` — line 277
+- `src/webview/webview_menu.rs` — line 44
+- `src/window.rs` — line 291
+
+## Proposed Fix
+
+Add a `[patch.crates-io]` section to `Cargo.toml` to force all transitive dependencies to use the same git version of `webrender_api`:
+
+```toml
+[patch.crates-io]
+webrender_api = { git = "https://github.com/servo/webrender", branch = "0.68" }
+```
+
+Alternatively, investigate whether `servo_malloc_size_of` can be configured to use the git version.
+
+## Error Count
+
+~60 errors directly caused by this issue.
+
+## Priority
+
+**Critical** — This must be fixed first as it blocks resolution of many other errors. Many errors in other categories are secondary effects of this dual-version conflict.
+
+## Labels
+
+`bug`, `dependencies`, `build`

--- a/docs/issues/issue-44-paint-message-api-changes.md
+++ b/docs/issues/issue-44-paint-message-api-changes.md
@@ -1,0 +1,68 @@
+# Issue #44: Update PaintMessage enum variant handling in compositor.rs
+
+## Summary
+
+The `PaintMessage` enum in the `paint_api` crate has undergone significant changes. Many variants have been removed, renamed, or had their field signatures changed. This causes ~25 errors in `src/compositor.rs`.
+
+## Removed Variants (no longer exist)
+
+| Variant | Line | Status |
+|---------|------|--------|
+| `PaintMessage::CreateOrUpdateWebView` | 583 | Removed |
+| `PaintMessage::RemoveWebView` | 588 | Removed |
+| `PaintMessage::TouchEventProcessed` | 592 | Removed |
+| `PaintMessage::CreatePng` | 596 | Removed |
+| `PaintMessage::IsReadyToSaveImageReply` | 603 | Removed |
+| `PaintMessage::LoadComplete` | 641 | Removed |
+| `PaintMessage::WebDriverMouseButtonEvent` | 648 | Removed |
+| `PaintMessage::WebDriverMouseMoveEvent` | 661 | Removed |
+| `PaintMessage::SendScrollNode` | 678 | Removed |
+| `PaintMessage::HitTest` | 793 | Removed |
+| `PaintMessage::AddImage` | 871 | Removed |
+| `PaintMessage::GetClientWindowRect` | 891, 955 | Removed |
+| `PaintMessage::GetScreenSize` | 900, 960 | Removed |
+| `PaintMessage::GetAvailableScreenSize` | 909, 965 | Removed |
+
+## Changed Variants
+
+### `SendInitialTransaction`
+- **Before**: 1 field `(pipeline)`
+- **After**: 2 fields `(WebViewId, WebRenderPipelineId)`
+- Lines: 670
+
+### `GenerateImageKey`
+- **Before**: 1 field `(sender)`
+- **After**: 2 fields `(WebViewId, GenericSender<ImageKey>)`
+- Lines: 810, 938
+
+### `SendDisplayList`
+- **Before**: had `display_list_receiver` field
+- **After**: has `display_list_info_receiver` and `display_list_data_receiver` instead
+- Lines: 710-714
+
+### `NewWebRenderFrameReady`
+- **Before**: 2 fields `(DocumentId, composite_needed)`
+- **After**: 3 fields `(PainterId, DocumentId, bool)`
+- Lines: 1123 (in verso.rs)
+
+## Related Changes
+
+- `PipelineExitSource::send()` method no longer exists (lines 624, 936)
+- `ScrollTreeNode::set_offset()` removed, replaced by `offset()` with different args (lines 402, 1282)
+- `set_scroll_offsets_for_node_with_external_scroll_id` renamed to `set_scroll_offset_for_node_with_external_scroll_id` (singular, different args) (line 688)
+
+## Affected File
+
+- `src/compositor.rs` — primary file affected
+
+## Proposed Fix
+
+Audit the current `PaintMessage` enum definition at the pinned servo rev (`e8aa7d51`) and update all match arms in `compositor.rs` to match the new API. Removed variants likely have replacement patterns in the new servo compositor code.
+
+## Error Count
+
+~25 errors
+
+## Labels
+
+`bug`, `api-change`, `compositor`

--- a/docs/issues/issue-45-embedder-msg-api-changes.md
+++ b/docs/issues/issue-45-embedder-msg-api-changes.md
@@ -1,0 +1,92 @@
+# Issue #45: Update EmbedderMsg and EmbedderToConstellationMessage API usage
+
+## Summary
+
+The `EmbedderMsg` enum and `EmbedderToConstellationMessage` enum in servo's `embedder_traits` and `constellation_traits` crates have undergone significant changes. Multiple variants have been removed, renamed, or had their signatures changed. This affects `src/verso.rs`, `src/webview/webview.rs`, `src/window.rs`, and related files.
+
+## Removed EmbedderMsg Variants
+
+| Variant | File:Line | Status |
+|---------|-----------|--------|
+| `EmbedderMsg::RequestAuthentication` | verso.rs:690, webview.rs:377 | Removed |
+| `EmbedderMsg::ShowContextMenu` | verso.rs:691, webview.rs:278,755,823,941 | Removed |
+| `EmbedderMsg::Keyboard` | verso.rs:698 | Removed |
+| `EmbedderMsg::WebResourceRequested` | verso.rs:707, webview.rs:189 | Removed |
+| `EmbedderMsg::SelectFiles` | verso.rs:710, webview.rs:392 | Removed |
+| `EmbedderMsg::ShowIME` | verso.rs:712, webview.rs:428 | Removed |
+| `EmbedderMsg::HideIME` | verso.rs:713, webview.rs:437 | Removed |
+| `EmbedderMsg::PlayGamepadHapticEffect` | verso.rs:718 | Removed |
+| `EmbedderMsg::StopGamepadHapticEffect` | verso.rs:719 | Removed |
+| `EmbedderMsg::ShowSelectElementMenu` | verso.rs:721 | Removed |
+
+## Changed EmbedderMsg Variants
+
+### `WebViewFocused`
+- **Before**: 1 field `(WebViewId)`
+- **After**: 2 fields `(WebViewId, bool)`
+- Lines: verso.rs:695, webview.rs:100,468,793,852
+
+## Removed/Changed EmbedderToConstellationMessage Variants
+
+| Variant | File:Line | Status |
+|---------|-----------|--------|
+| `SetCursor` | compositor.rs:490 | Removed |
+| `IsReadyToSaveImage` | compositor.rs:1989 | Removed |
+
+### `NewWebView`
+- **Before**: 3 args `(ServoUrl, WebViewId, ViewportDetails)`
+- **After**: 2 args `(ServoUrl, NewWebViewDetails)`
+- Lines: webview.rs:558, prompt.rs:272, webview_menu.rs:39, window.rs:270,311
+
+### `TraverseHistory`
+- **Before**: 2 args `(WebViewId, TraversalDirection)`
+- **After**: 3 args `(WebViewId, TraversalDirection, TraversalId)`
+- Lines: webview.rs:702,712, context_menu.rs:345,354, history_menu.rs:202,211
+
+### `ForwardInputEvent`
+- **Before**: accepts `InputEvent`
+- **After**: accepts `InputEventAndId`
+- Lines: compositor.rs:1426, window.rs:1200
+
+### `TickAnimation`
+- **Before**: `(pipeline_id, tick_type)`
+- **After**: `(Vec<WebViewId>)` — single arg
+- Lines: compositor.rs:1859
+
+## Removed Types
+
+| Type | File:Line |
+|------|-----------|
+| `ContextMenuResult` | webview.rs:284,761,828,942 |
+| `SimpleDialog` | webview.rs:300,312,324,502,797,856 |
+| `UserContentManager` | verso.rs:22 |
+| `WebDriverJSValue` (use `WebDriverJSResult`) | window.rs:9 |
+
+## Affected Files
+
+- `src/verso.rs`
+- `src/webview/webview.rs`
+- `src/webview/context_menu.rs`
+- `src/webview/history_menu.rs`
+- `src/webview/prompt.rs`
+- `src/webview/webview_menu.rs`
+- `src/window.rs`
+- `src/compositor.rs`
+
+## Proposed Fix
+
+1. Audit the current servo `embedder_traits` and `constellation_traits` at rev `e8aa7d51` to find the new API surface
+2. Remove handling for removed variants — these events may no longer be sent
+3. Update `NewWebView` calls to use `NewWebViewDetails` struct
+4. Update `TraverseHistory` calls to include `TraversalId`
+5. Wrap `InputEvent` in `InputEventAndId` where needed (use `.into()`)
+6. Replace `SimpleDialog` with the new dialog API
+7. Replace `ContextMenuResult` with the new context menu API
+
+## Error Count
+
+~35 errors
+
+## Labels
+
+`bug`, `api-change`, `embedder`

--- a/docs/issues/issue-46-keyboard-key-enum-restructured.md
+++ b/docs/issues/issue-46-keyboard-key-enum-restructured.md
@@ -1,0 +1,60 @@
+# Issue #46: Fix keyboard Key enum — named variants removed from keyboard-types
+
+## Summary
+
+The `keyboard_types::Key` enum has been restructured. All named key variants (like `Key::Escape`, `Key::F1`, `Key::Enter`, etc.) have been removed. The `get_servo_key_from_winit_key` function in `src/keyboard.rs` uses a macro that maps `NamedKey` variants to `Key` variants, but the `Key` enum no longer has these named variants.
+
+## Affected Variants (all removed from `Key` enum)
+
+**Function keys**: `Escape`, `F1`-`F12`
+
+**Navigation**: `PrintScreen`, `Pause`, `Insert`, `Home`, `Delete`, `End`, `PageDown`, `PageUp`, `ArrowLeft`, `ArrowUp`, `ArrowRight`, `ArrowDown`
+
+**Editing**: `Backspace`, `Enter`, `Tab`, `Copy`, `Paste`, `Cut`
+
+**Modifiers**: `Alt`, `Control`, `Shift`, `Meta`, `CapsLock`, `NumLock`
+
+**Composition**: `Compose`, `Convert`, `NonConvert`, `KanaMode`, `KanjiMode`
+
+**Media**: `MediaStop`, `MediaPlayPause`, `MediaTrackNext`, `MediaTrackPrevious`, `AudioVolumeMute`, `AudioVolumeDown`, `AudioVolumeUp`
+
+**Browser**: `BrowserBack`, `BrowserFavorites`, `BrowserForward`, `BrowserHome`, `BrowserRefresh`, `BrowserSearch`, `BrowserStop`
+
+**System**: `Power`, `Standby`, `WakeUp`, `LaunchApplication1`, `LaunchApplication2`, `LaunchMail`
+
+**Special**: `Unidentified`
+
+## Error Location
+
+`src/keyboard.rs` lines 48-108, specifically the `logical_to_winit_key!` macro invocation in `get_servo_key_from_winit_key()`.
+
+Total: ~50 individual errors from this single macro expansion.
+
+## Proposed Fix
+
+The `keyboard_types` crate (v0.8.3) likely restructured the `Key` enum. The fix should either:
+
+1. **Update the mapping** to use the new `Key` enum structure — possibly `Key::Named(NamedKey::...)` or a similar wrapper pattern
+2. **Use `embedder_traits::KeyboardEvent`** instead of `keyboard_types::KeyboardEvent` — the error at `window.rs:682` shows these are now different types. The servo `embedder_traits` defines its own `KeyboardEvent` that wraps the key info differently
+3. **Convert from winit keys directly to embedder_traits types** bypassing `keyboard_types` if it's no longer the intermediary
+
+## Related Error
+
+```
+error[E0308]: mismatched types (window.rs:682)
+  expected `embedder_traits::KeyboardEvent`, found `keyboard_types::KeyboardEvent`
+```
+
+This suggests servo now uses its own `KeyboardEvent` type. The keyboard mapping may need to target `embedder_traits::KeyboardEvent` instead.
+
+## Error Count
+
+~50 errors
+
+## Priority
+
+High — keyboard input is entirely broken without this fix.
+
+## Labels
+
+`bug`, `api-change`, `input`

--- a/docs/issues/issue-47-servo-api-signature-changes.md
+++ b/docs/issues/issue-47-servo-api-signature-changes.md
@@ -1,0 +1,79 @@
+# Issue #47: Update function/method signature changes across servo API
+
+## Summary
+
+Multiple servo API functions and methods have changed their parameter counts or types. This issue covers all signature-level changes not already tracked in other issues.
+
+## Changed Signatures
+
+### webrender API
+
+#### `generate_frame` (compositor.rs:984)
+- **Before**: 3 args `(id, present, reason)`
+- **After**: 4 args `(id, present, tracked: bool, reasons)`
+
+#### `hit_test` (compositor.rs:1503)
+- **Before**: 4 args `(document, pipeline_id, world_point, flags)`
+- **After**: 2 args `(document, world_point)`
+
+#### `new_frame_ready` trait method (verso.rs:1116)
+- **Before**: 5 params `(&self, document_id, scrolled, composite_needed, frame_publish_id)`
+- **After**: 4 params `(&self, document_id, frame_publish_id, &FrameReadyParams)`
+
+### Servo crate APIs
+
+#### `WebViewId::new()` (window.rs:260,280; webview.rs:539; context_menu.rs:86; history_menu.rs:31; prompt.rs:99)
+- **Before**: 0 args
+- **After**: 1 arg `(PainterId)`
+
+#### `SystemFontService::spawn` (verso.rs:281)
+- **Before**: 1 arg `(cross_process_paint_api)`
+- **After**: 2 args `(cross_process_paint_api, mem_profiler_chan)`
+
+#### `CanvasPaintThread::start` (verso.rs:286)
+- **Before**: 3 args `(cross_process_paint_api, system_font_service, public_resource_threads)`
+- **After**: 1 arg `(cross_process_paint_api)`
+
+#### `resource_thread::new_resource_threads` (verso.rs:267-277)
+- **Before**: returns `(public, private)` — 2-tuple
+- **After**: returns `(public, private, async_runtime)` — 3-tuple
+- Also requires `GenericEmbedderProxy<NetToEmbedderMsg>` instead of `GenericEmbedderProxy<EmbedderMsg>` for the embedder_proxy arg
+
+#### `Constellation::start` (verso.rs:319-327)
+- **Before**: 7 args including `canvas_create_sender` and `canvas_ipc_sender`
+- **After**: 6 args, needs `Receiver<EmbedderToConstellationMessage>` as first arg, removes canvas args
+
+#### `webdriver_server::start_server` (verso.rs:331)
+- **Before**: 2 args `(port, constellation_sender)`
+- **After**: 4 args `(port, sender, waker, preferences)`
+
+#### `BluetoothThreadFactory::new` (verso.rs:264)
+- **Before**: implemented for `IpcSender<BluetoothRequest>`
+- **After**: implemented for `GenericSender<BluetoothRequest>`
+
+### Constructor changes
+
+#### `CrossProcessPaintApi` (verso.rs:1185)
+- Constructor is now private. Use `CrossProcessPaintApi::new()` or `CrossProcessPaintApi::dummy()` instead.
+
+## Affected Files
+
+- `src/compositor.rs`
+- `src/verso.rs`
+- `src/window.rs`
+- `src/webview/webview.rs`
+- `src/webview/context_menu.rs`
+- `src/webview/history_menu.rs`
+- `src/webview/prompt.rs`
+
+## Proposed Fix
+
+Update each call site to match the new API signatures. Reference the servo source at rev `e8aa7d51` for the correct signatures.
+
+## Error Count
+
+~25 errors
+
+## Labels
+
+`bug`, `api-change`

--- a/docs/issues/issue-48-type-struct-field-changes.md
+++ b/docs/issues/issue-48-type-struct-field-changes.md
@@ -1,0 +1,102 @@
+# Issue #48: Fix struct/type field changes and type mismatches
+
+## Summary
+
+Several structs and types in the servo ecosystem have had fields added, removed, or renamed. Additionally, some types have been replaced with different types entirely. This issue tracks all field-level and type-level changes.
+
+## Struct Field Changes
+
+### `PaintHitTestResult` (compositor.rs)
+Fields removed:
+- `cursor` (line 472) — no longer available
+- `node` (line 1528) — removed
+- `scroll_tree_node` (line 1530, 1797) — removed
+- `point_relative_to_item` (line 1527) — removed
+Remaining fields: `pipeline_id`, `point_in_viewport`, `external_scroll_id`
+
+### `MouseMoveEvent` (compositor.rs:666, window.rs:452, compositor.rs:1622)
+- Missing field: `is_compatibility_event_for_touch` — must be provided in all `MouseMoveEvent` initializers
+
+### `MouseButtonAction` enum (compositor.rs:1436,1453,1643; window.rs:538)
+- `Click` variant removed — need to find replacement pattern
+
+### `Preferences` struct (config.rs:420)
+- `dom_svg_enabled` field removed — use `dom_webgpu_enabled` or remove
+
+### `Opts` struct (verso.rs)
+- `shaders_dir` field removed (line 203)
+- `webdriver_port` field removed (line 330)
+- `wait_for_stable_image` field removed (line 352)
+
+### `DiagnosticsLogging` struct (verso.rs)
+- `disable_share_style_cache` field removed (line 150)
+- `dump_style_statistics` field removed (line 152) — use `style_statistics`
+- `webrender_stats` field removed (line 190)
+- `convert_mouse_to_touch` field removed (line 353)
+
+### `InitialConstellationState` struct (verso.rs)
+Fields removed:
+- `compositor_proxy` (line 300) — use `paint_proxy`
+- `webrender_document` (line 309)
+- `webrender_api_sender` (line 310)
+- `webrender_external_images` (line 313) — use `webrender_external_image_id_manager`
+- `user_contents` (line 314)
+
+### `SharedRasterImage` / favicon (window.rs:1010)
+- No direct `width`/`height` fields — use `metadata.width`/`metadata.height`
+- No `bytes()` method — `bytes` is a field, not a method
+
+### `ImageUpdate::AddImage` / `UpdateImage` (compositor.rs:818,823)
+- **Before**: 3 fields `(key, desc, data)`
+- **After**: 4 fields `(key, desc, data, is_animated_image)`
+
+## Type Replacement Changes
+
+### `WebViewPoint` vs `DevicePoint` (compositor.rs, window.rs)
+Input events now use `WebViewPoint` enum instead of `Point2D<f32, DevicePixel>`:
+- compositor.rs: lines 654, 1416, 1420, 1537, 1569, 1574, 1577, 1608, 1609, 1615, 1622, 1628, 1636, 1644
+- window.rs: lines 508, 515, 537, 452
+
+### `InputEvent` → `InputEventAndId` (compositor.rs:1426,1546; window.rs:1200)
+`ForwardInputEvent` now expects `InputEventAndId` instead of `InputEvent`. Use `.into()` to convert.
+
+### `ScrollEvent` type mismatch (compositor.rs:1587,1678,1681,1689)
+`compositor::ScrollEvent` and `scroll_coalescing::ScrollEvent` are now distinct types.
+
+### `PipelineId` ↔ `NamespaceIndex<PipelineIndex>` (compositor.rs)
+Conversion issues between these types at lines 1115, 1509, 1808, 1859, 1980, 2251.
+
+### `IpcSender` → `GenericSender` (webview.rs:370)
+`PromptSender::AllowDenySender` expects `IpcSender<AllowOrDeny>` but receives `GenericSender<AllowOrDeny>`.
+
+### `keyboard_types::KeyboardEvent` → `embedder_traits::KeyboardEvent` (window.rs:682)
+Servo now uses its own `KeyboardEvent` type.
+
+## Response Type Changes
+
+### `AlertResponse::default()` (window.rs:1046; webview.rs:860,870)
+No `default()` method. Use `default_color()` or the appropriate constructor.
+
+### `ConfirmResponse::default()` (window.rs:1049; webview.rs:878)
+No `default()` method.
+
+### `PromptResponse::default()` (window.rs:1052; webview.rs:521,530,577,625,630,802,896,901)
+No `default()` method.
+
+## Affected Files
+
+- `src/compositor.rs`
+- `src/verso.rs`
+- `src/config.rs`
+- `src/window.rs`
+- `src/webview/webview.rs`
+- `src/webview/prompt.rs`
+- `src/webview/webview_menu.rs`
+
+## Error Count
+
+~60 errors
+
+## Labels
+
+`bug`, `api-change`

--- a/docs/issues/issue-49-removed-types-and-functions.md
+++ b/docs/issues/issue-49-removed-types-and-functions.md
@@ -1,0 +1,110 @@
+# Issue #49: Handle removed types, functions, and enum variants
+
+## Summary
+
+Several types, functions, and enum variants have been completely removed from the servo dependency crates. These need replacement implementations or removal of the code that uses them.
+
+## Removed from `webrender_api`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `HitTestFlags` | Type | compositor.rs:41 | Import and usage removed |
+| `HitTestInfo` | Type | compositor.rs:358 | Used in `PipelineDetails` struct |
+| `ScrollState` | Struct | compositor.rs:1929 | Used for scroll state tracking |
+
+## Removed from `embedder_traits`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `AnimationTickType` | Type | compositor.rs:1851,1853,1856 | Used for tick animation |
+
+## Removed from `profile_traits`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `ProfilerCategory::Compositing` | Variant | compositor.rs:2062 | Profiling category |
+
+## Removed from `servo_config`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `set_options` | Function | config.rs:409 | Options initialization |
+
+## Removed from `embedder_traits::resources`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `Resource::RippyPNG` | Variant | config.rs:458 | Resource file reference |
+
+## Removed from `net_traits`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `Response::network_internal_error` | Method | config.rs:525 | Use `Response::network_error` instead |
+
+## Removed from `webrender_api` / epoch
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `Epoch::as_u16()` | Method | compositor.rs:1519 | No longer available on Epoch |
+
+## Removed from `paint_api`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `PaintDisplayListInfo::hit_test_info` | Field | compositor.rs:769 | Field no longer exists |
+
+## Removed crate
+
+| Crate | Location | Notes |
+|-------|----------|-------|
+| `webgpu` (as external crate) | verso.rs:38 | `use webgpu;` — not available as standalone import when feature disabled |
+
+## Removed from `embedder_traits` / `webdriver`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `WebDriverScriptCommand::ExecuteScript` | Variant | webview.rs:1041 | Use updated command |
+| `WebViewId.0` field access | Privacy | webview.rs:1040 | Field is now private |
+
+## Removed from `touch`
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `InputEventResult::DefaultPrevented` (tuple variant) | Pattern | touch.rs:220 | Now an associated constant, not tuple |
+| `InputEventResult::DefaultAllowed` | Variant | touch.rs:221 | No longer exists |
+
+## Removed from `lock_api` / parking_lot
+
+| Item | Type | Location | Notes |
+|------|------|----------|-------|
+| `MutexGuard::unwrap()` | Method | config.rs:521 | parking_lot MutexGuard doesn't need unwrap |
+
+## Affected Files
+
+- `src/compositor.rs`
+- `src/config.rs`
+- `src/verso.rs`
+- `src/window.rs`
+- `src/touch.rs`
+- `src/webview/webview.rs`
+
+## Proposed Fix
+
+1. Remove imports/usage of deleted types
+2. Replace `HitTestInfo` with the new hit test result type
+3. Replace `AnimationTickType` with the new animation tick API
+4. Replace `set_options` with the new configuration method
+5. Remove `Resource::RippyPNG` handling
+6. Replace `network_internal_error` with `network_error`
+7. Guard `use webgpu;` behind the `webgl` feature flag
+8. Update touch event result handling to match new `InputEventResult` API
+9. Remove `.unwrap()` on parking_lot `MutexGuard`
+
+## Error Count
+
+~20 errors
+
+## Labels
+
+`bug`, `api-change`, `cleanup`

--- a/docs/issues/issue-50-verso-initialization-changes.md
+++ b/docs/issues/issue-50-verso-initialization-changes.md
@@ -1,0 +1,98 @@
+# Issue #50: Update Verso initialization and configuration code
+
+## Summary
+
+The `Verso::new()` initialization in `src/verso.rs` and configuration code in `src/config.rs` have multiple errors due to changed servo APIs for browser setup, resource thread creation, constellation initialization, and webdriver configuration.
+
+## Configuration Issues (config.rs)
+
+### `set_options(opts)` removed (line 409)
+The `servo_config::opts::set_options()` function no longer exists. Need to find the new way to initialize servo options.
+
+### `Preferences` struct changes (line 420)
+`dom_svg_enabled` field doesn't exist. Compiler suggests `dom_webgpu_enabled`.
+
+### `Resource::RippyPNG` removed (line 458)
+Resource variant no longer exists.
+
+### `Response` API changes (lines 521, 525)
+- `response.body.lock().unwrap()` — parking_lot mutex doesn't use `unwrap()`, use `response.body.lock()` directly
+- `Response::network_internal_error(msg)` — use `Response::network_error(msg)` instead
+
+## Initialization Issues (verso.rs)
+
+### Removed/renamed imports (lines 13-14, 22, 38)
+- `WebrenderExternalImageHandlers` → `WebRenderExternalImageHandlers`
+- `WebrenderImageHandlerType` → `WebRenderImageHandlerType`
+- `user_contents::UserContentManager` → doesn't exist (only `UserContentManagerId`)
+- `use webgpu;` — not available as standalone crate import
+
+### `DiagnosticsLogging` field changes (lines 150-190)
+- `disable_share_style_cache` → removed
+- `dump_style_statistics` → `style_statistics`
+- `webrender_stats` → removed
+- `convert_mouse_to_touch` → removed
+
+### `Opts` field changes (lines 203, 330, 352)
+- `shaders_dir` → removed
+- `webdriver_port` → removed
+- `wait_for_stable_image` → removed
+
+### External image handlers type inference (line 232)
+Need explicit type annotation for `Box<_>` around `external_image_handlers`.
+
+### `BluetoothThreadFactory` impl change (line 264)
+Now implemented for `GenericSender<BluetoothRequest>`, not `IpcSender<BluetoothRequest>`.
+
+### `resource_thread::new_resource_threads` changes (lines 267-277)
+- Returns 3-tuple `(public, private, async_runtime)` instead of 2-tuple
+- Requires `GenericEmbedderProxy<NetToEmbedderMsg>` instead of `GenericEmbedderProxy<EmbedderMsg>`
+
+### `SystemFontService::spawn` (line 281)
+Now takes 2 args (added `ProfilerChan`).
+
+### `CanvasPaintThread::start` (line 286)
+Now takes 1 arg instead of 3 (removed `system_font_service` and `public_resource_threads`).
+
+### `InitialConstellationState` fields (lines 300-314)
+Removed: `compositor_proxy`, `webrender_document`, `webrender_api_sender`, `webrender_external_images`, `user_contents`
+Available: `paint_proxy`, `public_storage_threads`, `private_storage_threads`, `webrender_external_image_id_manager`, `privileged_urls`, `async_runtime`
+
+### `Constellation::start` (lines 319-327)
+New arg list: needs `Receiver<EmbedderToConstellationMessage>` first, removed canvas args.
+
+### `webdriver_server::start_server` (line 331)
+Now takes 4 args: `(port, sender, waker, preferences)`.
+
+### Constellation sender type (lines 343, 361, 363, 388)
+`constellation_sender` is `()` instead of `Sender<EmbedderToConstellationMessage>`. The constellation start function likely now returns the sender differently.
+
+### `CrossProcessPaintApi` constructor (line 1185)
+Constructor is private. Use `CrossProcessPaintApi::new()` or `CrossProcessPaintApi::dummy()`.
+
+### Paint message receiver type (line 1200)
+Expected `Receiver<PaintMessage>`, got `Receiver<Result<PaintMessage, Box<ErrorKind>>>`.
+
+## Affected Files
+
+- `src/config.rs`
+- `src/verso.rs`
+
+## Proposed Fix
+
+This requires a comprehensive rewrite of the `Verso::new()` function and `Config` initialization to match the new servo initialization API. Key references:
+- Check servo's own embedder code at rev `e8aa7d51` for initialization patterns
+- Review `InitialConstellationState` available fields
+- Review `Constellation::start` new signature
+
+## Error Count
+
+~40 errors
+
+## Priority
+
+**Critical** — the application cannot start without these fixes.
+
+## Labels
+
+`bug`, `api-change`, `initialization`

--- a/docs/issues/issue-51-compositor-hit-test-scroll-changes.md
+++ b/docs/issues/issue-51-compositor-hit-test-scroll-changes.md
@@ -1,0 +1,90 @@
+# Issue #51: Update compositor hit testing, scrolling, and input dispatch
+
+## Summary
+
+The compositor's hit testing, scroll handling, and input event dispatching code needs significant updates to match the new servo paint/compositing API. This covers the interconnected changes in `src/compositor.rs` that affect how user input is processed, how hit tests are performed, and how scroll events are handled.
+
+## Hit Testing Changes
+
+### `hit_test` method (line 1503)
+- **Before**: `hit_test(document, pipeline_id, world_point, flags)` — 4 args
+- **After**: `hit_test(document, world_point)` — 2 args (no pipeline filter, no flags)
+
+### `PaintHitTestResult` struct (lines 1526-1530)
+Lost most fields, only retains `pipeline_id`, `point_in_viewport`, `external_scroll_id`:
+- `point_in_viewport` expects `Point2D<f32, CSSPixel>` not `Point2D<f32, UnknownUnit>`
+- Removed: `point_relative_to_item`, `node`, `cursor`, `scroll_tree_node`
+
+### `HitTestResultItem` field changes (line 1527)
+- `point_relative_to_item` field no longer exists on `HitTestResultItem`
+
+### `HitTestFlags` removed (line 41)
+Import and all usage must be removed.
+
+### `HitTestInfo` removed (line 358)
+Used in `PipelineDetails.hit_test_items` — this field/type needs replacement.
+
+### Epoch conversion (line 1519)
+`Epoch::as_u16()` method doesn't exist. Need alternative for comparing epochs.
+
+### Cursor handling (lines 472-490)
+- `PaintHitTestResult` no longer has a `cursor` field
+- `EmbedderToConstellationMessage::SetCursor` doesn't exist
+- Cursor updates need a different mechanism
+
+## Scroll Handling Changes
+
+### `ScrollState` removed (line 1929)
+The `ScrollState` struct no longer exists. Scroll state tracking needs to be reimplemented.
+
+### `ScrollTreeNode::set_offset` removed (lines 402, 1282)
+Method replaced with `offset()` (getter only, different signature).
+
+### `set_scroll_offsets_for_node_with_external_scroll_id` → singular (line 688)
+Renamed to `set_scroll_offset_for_node_with_external_scroll_id` with different args (needs `ScrollType` parameter).
+
+### `scroll_node_or_ancestor` (line 1806)
+- **Before**: 2 args `(scroll_tree_node, scroll_location)`
+- **After**: 3 args `(scroll_tree_node, scroll_location, scroll_type)`
+- Also `ScrollLocation` type comes from wrong webrender_api version
+
+### `ScrollEvent` type conflict (lines 1587, 1678, 1681, 1689)
+`compositor::ScrollEvent` (private) vs `scroll_coalescing::ScrollEvent` (public) are now distinct types with incompatible fields.
+
+## Input Dispatch Changes
+
+### `WebViewPoint` vs `DevicePoint` (multiple lines)
+All input event points now use `WebViewPoint` enum instead of raw `Point2D<f32, DevicePixel>`. Affected methods:
+- `hit_test_at_point` — expects `DevicePoint` but receives `WebViewPoint`
+- `update_cursor` — expects `DevicePoint` but receives `WebViewPoint`
+- `on_touch_down/move/up/cancel` — expect `Point2D<f32, DevicePixel>` but receive `WebViewPoint`
+- `simulate_mouse_click` — expects `DevicePoint` but receives `WebViewPoint`
+- Mouse button/move events create `WebViewPoint` where `DevicePoint` expected (and vice versa)
+
+### `MouseButtonAction::Click` removed (lines 1436, 1453, 1643)
+No `Click` variant exists. Need to find the new way to represent click actions.
+
+### `MouseMoveEvent` requires `is_compatibility_event_for_touch` (lines 666, 1622)
+New required field in `MouseMoveEvent` initializer.
+
+## Affected File
+
+`src/compositor.rs` — all changes are in this file.
+
+## Proposed Fix
+
+1. Update `hit_test_at_point` to use the simplified 2-arg hit_test API
+2. Reconstruct `PaintHitTestResult` from the reduced available fields
+3. Implement `WebViewPoint` → `DevicePoint` conversion where needed
+4. Unify the `ScrollEvent` types or add conversion
+5. Update scroll methods to use new signatures
+6. Handle cursor updates through the new mechanism
+7. Replace `MouseButtonAction::Click` with the correct variant
+
+## Error Count
+
+~40 errors
+
+## Labels
+
+`bug`, `api-change`, `compositor`, `input`


### PR DESCRIPTION
…t check

Categorize all build errors into 8 distinct issues (#43-#51):
- #43: webrender_api dual version conflict (~60 errors)
- #44: PaintMessage enum variant changes (~25 errors)
- #45: EmbedderMsg/constellation API changes (~35 errors)
- #46: keyboard_types Key enum restructuring (~50 errors)
- #47: Servo API function signature changes (~25 errors)
- #48: Struct field and type mismatch changes (~60 errors)
- #49: Removed types, functions, and enum variants (~20 errors)
- #50: Verso initialization and config changes (~40 errors)
- #51: Compositor hit test, scroll, and input changes (~40 errors)

https://claude.ai/code/session_01XTzo7XDthVeXn6GYDBcbkR